### PR TITLE
add checks for failed datetime parsing

### DIFF
--- a/controllers/webmention.php
+++ b/controllers/webmention.php
@@ -134,10 +134,16 @@ $app->post('/(:lang/)webmention', function($lang='en') use($app) {
     }
 
     if(array_key_exists('published', $post)) {
-      $published = new DateTime($post['published']);
-      $record['date'] = $published;
-      $utcdate = clone $published;
-      $utcdate->setTimeZone(new DateTimeZone('UTC'));
+      try {
+        $published = new DateTime($post['published']);
+      } catch($e) {
+        $notices[] = 'Failed to parse published date';
+      }
+      if(isset($published)) {
+        $record['date'] = $published;
+        $utcdate = clone $published;
+        $utcdate->setTimeZone(new DateTimeZone('UTC'));
+      }
     } else {
       $notices[] = 'No published date found';
     }
@@ -151,8 +157,12 @@ $app->post('/(:lang/)webmention', function($lang='en') use($app) {
     }
 
     if(isset($post['start'])) {
-      $start = new DateTime($post['start']);
-      if($start) {
+      try {
+        $start = new DateTime($post['start']);
+      } catch($e) {
+        $notices[] = 'Failed to parse start date';
+      }
+      if(isset($start) && $start) {
         $record['date'] = $start;
         $utcdate = clone $start;
         $utcdate->setTimeZone(new DateTimeZone('UTC'));

--- a/controllers/webmention.php
+++ b/controllers/webmention.php
@@ -136,7 +136,7 @@ $app->post('/(:lang/)webmention', function($lang='en') use($app) {
     if(array_key_exists('published', $post)) {
       try {
         $published = new DateTime($post['published']);
-      } catch($e) {
+      } catch(Exception $e) {
         $notices[] = 'Failed to parse published date';
       }
       if(isset($published)) {
@@ -159,7 +159,7 @@ $app->post('/(:lang/)webmention', function($lang='en') use($app) {
     if(isset($post['start'])) {
       try {
         $start = new DateTime($post['start']);
-      } catch($e) {
+      } catch(Exception $e) {
         $notices[] = 'Failed to parse start date';
       }
       if(isset($start) && $start) {


### PR DESCRIPTION
So I just read this (Dutch) article by Frank, stating that he has problems with IndieNews. https://diggingthedigital.com/indienews-werkt-weer/

A quick webmention via the form gives me the following Slim Application Error (which you should probably hide by disabling debug):
> Type: Exception
> Message: DateTime::__construct(): Failed to parse time string (14 oktober 2020) at position 0 (1): Unexpected character
> File: /web/sites/news.indieweb.org/controllers/webmention.php
> Line: 137

Seems like `new DateTime($string)` cannot really deal with human written Dutch dates. The fault is probably partially with Frank, but IndieNews should not crash on it, so that’s what I tried to fix in this PR :)

I tried to be close to your coding style, but I didn’t see a catch so I guessed. Note the extra `isset()` because `$published` might not have been defined if PHP throws during the parsing of the DateTime.


In a followup you should probably decide what you want to do if someone makes a `h-entry` with a `p-published` of `now`, `yesterday` or `july 2019 + 3 weeks`.

https://www.php.net/manual/en/datetime.formats.php