### PR TITLE
Fetch HTML from source instead of ActivityStreams JSON

### DIFF
--- a/controllers/webmention.php
+++ b/controllers/webmention.php
@@ -105,7 +105,7 @@ $app->post('/{lang:'.LANG_REGEX.'}/webmention', function($request, $response, $a
   # Now fetch and parse the page looking for Microformats
   $xray = new p3k\XRay();
   $xray->http = new p3k\HTTP('IndieNews/1.0.0 (https://news.indieweb.org/)');
-  $xrayresponse = $xray->parse($sourceURL, ['ignore-as2' => true]);
+  $xrayresponse = $xray->parse($sourceURL, ['ignore-as2' => true, 'accept' => 'html']);
 
   if(isset($xrayresponse['error'])) {
     return $error($xrayresponse['error'], 'An error occurred while attempting to fetch the source URL: ' . $xrayresponse['error_description']);


### PR DESCRIPTION
Sites that content-negotiate (e.g. WordPress with the ActivityPub plugin) were returning an ActivityStreams JSON representation to XRay, because XRay's default Accept header offers application/activity+json alongside text/html. The AS2 object has no u-syndication/u-category link, so submissions failed with no_link_found even when the page's HTML had a valid u-category link to news.indieweb.org.